### PR TITLE
Fix issue with broken certificate chain

### DIFF
--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -192,7 +192,7 @@ ssl_verify_fun(Hostname) ->
                 Valid = case lists:foldl(Compare, CrtList, BinHostList) of
                             [] -> true;
                             Other -> Other
-                        end,
+                        end == true,
                 case Valid and LongEnough of
                     true -> true;
                     _ -> CurValid


### PR DESCRIPTION
Connecting to Azure AD I noticed TLS issues even though the certificate was valid. When the foldl method has some leftover in `Other`, the case statement below crashes as it expects a boolean, causing the loop to break and thus incorrectly marking the certificate as false.