### PR TITLE
Improve HostName Check for Wildcard Certificates

### DIFF
--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -152,6 +152,7 @@ ssl_options(HostName, BaseOptions) ->
             {ok, [{ssl, [
                     {verify, verify_peer},
                     {verify_fun, VerifyFun},
+                    {customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]},
                     {cacertfile, CaCertFile},
                     {depth, Depth}
                    ] }


### PR DESCRIPTION
Needed to make it work with `https://idp.bexio.com/.well-known/openid-configuration`