### PR TITLE
Add missing ssl_verify_hostname application

### DIFF
--- a/src/oidcc.app.src
+++ b/src/oidcc.app.src
@@ -5,7 +5,7 @@
               {registered,[oidcc_sup,oidcc_openid_provider_mgr,
                            oidcc_openid_provider_sup,oidcc_session_mgr,
                            oidcc_session_sup]},
-              {applications,[kernel,stdlib,ssl,public_key,crypto,erljwt,
+              {applications,[kernel,stdlib,ssl,public_key,crypto,erljwt,ssl_verify_hostname,
                              base64url,inets]},
               {maintainers,["Bas Wegh"]},
               {licenses,["Apache 2.0"]},


### PR DESCRIPTION
If the application is not loaded, then it fails to communicate via HTTPS with a mysterious error.